### PR TITLE
Fix full build on 64-bit hosts and SD flashing on USB card readers

### DIFF
--- a/SOURCE/Makefile
+++ b/SOURCE/Makefile
@@ -603,7 +603,7 @@ sqlite3-clean:
 	@make -C $(PACKAGES_DIR)/$(SQLITE3) clean distclean
 
 $(PACKAGES_DIR)/$(SQLCIPHER)/config.status:
-	@cd $(PACKAGES_DIR)/$(SQLCIPHER); ./configure --host=$(HOST) --prefix=$(SDROOT) --sysconfdir=$(SDROOT)/etc/config --datarootdir=$(SDROOT)/usr/share --with-sysroot=$(STAGING_DIR)/$(SDROOT) CFLAGS="-I$(STAGING_DIR)/$(SDROOT)/include -DSQLITE_HAS_CODEC -DSQLCIPHER_CRYPTO_OPENSSL" LDFLAGS="-L$(STAGING_DIR)/$(SDROOT)/lib -lssl -lcrypto"
+	@cd $(PACKAGES_DIR)/$(SQLCIPHER); ./configure --host=$(HOST) --prefix=$(SDROOT) --sysconfdir=$(SDROOT)/etc/config --datarootdir=$(SDROOT)/usr/share --with-sysroot=$(STAGING_DIR)/$(SDROOT) --disable-tcl CFLAGS="-I$(STAGING_DIR)/$(SDROOT)/include -DSQLITE_HAS_CODEC -DSQLCIPHER_CRYPTO_OPENSSL" LDFLAGS="-L$(STAGING_DIR)/$(SDROOT)/lib -lssl -lcrypto"
 
 $(PACKAGES_DIR)/$(SQLCIPHER)/sqlcipher: $(PACKAGES_DIR)/$(SQLCIPHER)/config.status
 	@make -C $(PACKAGES_DIR)/$(SQLCIPHER) -j$(nproc)

--- a/SOURCE/Makefile
+++ b/SOURCE/Makefile
@@ -1256,7 +1256,7 @@ $(BUILD_HACK)/etc/version.txt:
 	
 $(BUILD_DIR)/LICENSE.md:
 	@cp $(ROOT_DIR)/LICENSE.MIT $(BUILD_DIR)/LICENSE.MIT
-	@cp $(ROOT_DIR)/LICENSE.md $@
+	@cp $(ROOT_DIR)/LICENSE.md $@ 2>/dev/null || cp $(ROOT_DIR)/LICENSE.MIT $@
 	@touch $@
 
 build: $(BUILD_DIR)/install.ps1 $(BUILD_HACK)/bin/radare2 $(BUILD_HACK)/bin/r2agent $(BUILD_HACK)/bin/r2r $(BUILD_HACK)/bin/rasign2 $(BUILD_HACK)/bin/rax2 $(BUILD_HACK)/bin/ragg2 $(BUILD_HACK)/bin/rarun2 $(BUILD_HACK)/bin/rabin2 \

--- a/SOURCE/Makefile
+++ b/SOURCE/Makefile
@@ -861,7 +861,7 @@ libilbc-clean:
 
 $(PACKAGES_DIR)/$(OPENJPEG)/build/Makefile:
 	@mkdir -p $(PACKAGES_DIR)/$(OPENJPEG)/build
-	@cd $(PACKAGES_DIR)/$(OPENJPEG)/build; cmake .. -DCMAKE_INSTALL_PREFIX=$(STAGING_DIR)/$(SDROOT)
+	@cd $(PACKAGES_DIR)/$(OPENJPEG)/build; cmake .. -DCMAKE_INSTALL_PREFIX=$(STAGING_DIR)/$(SDROOT) -DBUILD_CODEC=OFF
 	
 $(PACKAGES_DIR)/$(OPENJPEG)/libopenjp2.so: $(PACKAGES_DIR)/$(OPENJPEG)/build/Makefile
 	@make -C $(PACKAGES_DIR)/$(OPENJPEG)/build -j$(nproc)

--- a/SOURCE/Makefile
+++ b/SOURCE/Makefile
@@ -1139,8 +1139,9 @@ $(BUILD_HACK)/bin/pydoc:
 	@cp $(STAGE_HACK)/bin/pydoc3.13 $@ >/dev/null 2>&1 || true
 
 $(BUILD_HACK)/bin/pip:
+	@mkdir -p $(STAGING_DIR)/$(SDROOT)/lib/python3.13/site-packages $(BUILD_HACK)/lib/python3.13/site-packages >/dev/null 2>&1 || true
 	@for m in $(SRC_DIR)/modules/python/*; do \
-		cp -r $$m $(STAGING_DIR)/$(SDROOT)/lib/python3.13/site-packages/; \
+		cp -r $$m $(STAGING_DIR)/$(SDROOT)/lib/python3.13/site-packages/ >/dev/null 2>&1 || true; \
 	done
 	@cp -aL $(STAGING_DIR)/$(HOST_DIR)/lib/python3.13/site-packages/* $(BUILD_HACK)/lib/python3.13/site-packages/ >/dev/null 2>&1 || true
 	@cp $(STAGING_DIR)/$(HOST_DIR)/bin/pip3.13 $@ >/dev/null 2>&1 || true

--- a/SOURCE/src/sdcard/install.sh
+++ b/SOURCE/src/sdcard/install.sh
@@ -61,42 +61,43 @@ if [ "$use_sd_config" = "1" ]; then
 	umount $mount1 >/dev/null 2>&1
 fi
 
-# SD Groesse
-sdsize=`fdisk -l /dev/mmcblk0 | grep "^Disk" | grep bytes | awk '{print $5}'`
-sdsect=`fdisk -l /dev/mmcblk0 | grep "^Disk" | grep bytes | awk '{print $7}'`
-p2size=$((1024 * 1024 * 1024))
-p1size=$(($sdsize - $p2size))
-p1sect=`awk "BEGIN {print ($sdsect / $sdsize * $p1size)}"`
+# SD Groesse (blockdev statt fdisk-Ausgabe zu parsen)
+sdsize=$(blockdev --getsize64 /dev/$disk)
+p2size=$((1024 * 1024 * 1024))                 # Partition 2 = 1 GiB
+# Partition 1 in ganzen MiB; wird als "+<MiB>M" an fdisk uebergeben. Vermeidet die
+# Fliesskomma-/Wissenschaftsnotation (z.B. 6.04e+07) die fdisk nicht als Sektor parsen kann.
+p1mib=$(( (sdsize - p2size) / 1024 / 1024 ))
+
+# Vorhandene (evtl. automatisch gemountete) Partitionen aushaengen
+umount /dev/${disk}?* 2>/dev/null
 
 # Partitionen loeschen
 echo "Loesche vorhandene Partitionen auf /dev/$disk ..."
 wipefs --all --force /dev/$disk
 
-# Partitionierung durchfuehren
+# Partitionierung mit sfdisk (skriptfaehig statt fragiler fdisk-Tastendruck-Sequenz):
+#   Partition 1 = p1mib MiB, Partition 2 = Rest, beide Typ 0x0c (W95 FAT32 LBA)
 echo "Erstelle neue Partitionen..."
-echo "o
-n
-p
-1
+sfdisk --wipe always --wipe-partitions always /dev/$disk <<EOF
+label: dos
+size=${p1mib}MiB, type=0c
+type=0c
+EOF
 
-$p1sect
-n
-p
-2
-
-
-t
-1
-0c
-t
-2
-0c
-w" | fdisk /dev/$disk >/dev/null 2>&1
-
-# Warten, bis das System die Partitionen erkennt
+# Kernel die neue Partitionstabelle einlesen lassen und pruefen, dass beide da sind
+sync
+partprobe /dev/$disk 2>/dev/null
+udevadm settle 2>/dev/null
 sleep 2
-partprobe /dev/$disk
-sleep 10
+if [ ! -b /dev/${part}1 ] || [ ! -b /dev/${part}2 ]; then
+	echo "Fehler: /dev/${part}1 bzw. /dev/${part}2 wurde nicht angelegt (Partitionstabelle nicht neu eingelesen). Abbruch." >&2
+	exit 1
+fi
+
+# Vor dem Formatieren aushaengen (falls der Desktop automatisch gemountet hat)
+udevadm settle 2>/dev/null
+umount /dev/${part}1 2>/dev/null
+umount /dev/${part}2 2>/dev/null
 
 # Partitionen formatieren
 echo "Formatiere Partitionen als FAT32..."

--- a/SOURCE/src/sdcard/install.sh
+++ b/SOURCE/src/sdcard/install.sh
@@ -31,13 +31,20 @@ if ! lsblk -d -o NAME,ROTA | grep "^$disk" | awk '{print $2}' | grep "0"; then
     exit 1
 fi
 
+# Partitions-Namensschema bestimmen: mmcblk0/nvme (endet auf Ziffer) -> "p"-Trenner,
+# sd*/hd*/vd* -> kein Trenner (z.B. sdb -> sdb1, mmcblk0 -> mmcblk0p1)
+case "$disk" in
+	*[0-9]) part="${disk}p" ;;
+	*)      part="${disk}" ;;
+esac
+
 # Mount-Punkte erstellen
 mount1=$(mktemp -d)
 mount2=$(mktemp -d)
 
 if [ "$use_sd_config" = "1" ]; then
-	mount /dev/${disk}p1 $mount1 >/dev/null 2>&1
-	mount /dev/${disk}p2 $mount2 >/dev/null 2>&1
+	mount /dev/${part}1 $mount1 >/dev/null 2>&1
+	mount /dev/${part}2 $mount2 >/dev/null 2>&1
 	
 	for m in $mount1 $mount2; do
 		if [ -f "$m/HACK/etc/hack_custom.conf" ]; then
@@ -92,12 +99,12 @@ sleep 10
 
 # Partitionen formatieren
 echo "Formatiere Partitionen als FAT32..."
-mkfs.vfat -F32 /dev/${disk}p1
-mkfs.vfat -F32 /dev/${disk}p2
+mkfs.vfat -F32 /dev/${part}1
+mkfs.vfat -F32 /dev/${part}2
 
 # Partitionen mounten
-mount /dev/${disk}p1 "$mount1"
-mount /dev/${disk}p2 "$mount2"
+mount /dev/${part}1 "$mount1"
+mount /dev/${part}2 "$mount2"
 
 # Dateien kopieren
 echo "Kopiere Dateien auf die erste Partition..."

--- a/SOURCE/src/sdcard/install.sh
+++ b/SOURCE/src/sdcard/install.sh
@@ -25,8 +25,9 @@ if [ ! -b "/dev/$disk" ]; then
     exit 1
 fi
 
-# Sicherheitspruefung: Ist es ein Wechselmedium?
-if ! lsblk -d -o NAME,ROTA | grep "^$disk" | awk '{print $2}' | grep "0"; then
+# Sicherheitspruefung: Ist es ein Wechselmedium? (RM=1, nicht ROTA:
+# moderne interne SSDs sind ROTA=0 und wuerden die alte Pruefung faelschlich bestehen)
+if [ "$(lsblk -dno RM /dev/$disk 2>/dev/null)" != "1" ]; then
     echo "Fehler: Der gewaehlte Datentraeger ist KEIN Wechselmedium! Abbruch."
     exit 1
 fi


### PR DESCRIPTION
## What this does

Small fixes so the project builds on a normal 64-bit Linux machine and so the
SD card install script works with USB card readers (device names like `sdb`),
not only with `mmcblk0`.

I hit each of these while doing a full `make all` and then flashing a card.
Every fix is its own commit so they are easy to read and review.

## Build fixes (Makefile)

- **sqlcipher: add `--disable-tcl`** — the build tried to compile the TCL
  extension using the host header `/usr/include/tcl.h`, which needs
  `gnu/stubs-32.h` (32-bit files). The firmware does not use the TCL
  extension, so it is turned off.
- **openjpeg: add `-DBUILD_CODEC=OFF`** — the extra command line tools need
  `zlib.h` and `tiffio.h` from the host. Only the library is needed for
  ffmpeg, so the tools are skipped.
- **pip step: make the target folder and do not stop the build** — with the
  default `WITH_PYTHON = 2`, python is not staged, but the build still copies
  the python modules. The first copy had no target folder and no `|| true`, so
  it stopped the whole build. Now it behaves like the `python`/`idle`/`pydoc`
  rules, which already ignore this when python is off.
- **LICENSE.md: use LICENSE.MIT as fallback** — the build copied `LICENSE.md`,
  but there is no such file in `SOURCE/` (only `LICENSE.MIT`), so it stopped at
  the last step. Now it falls back to `LICENSE.MIT`.

## SD card script fixes (install.sh)

- **Build partition names for sdX/nvme, not only mmcblk** — the script asked
  for the disk name (e.g. `sdb`) but always used `${disk}p1`. The `p` is only
  right for `mmcblk0`/`nvme`. For `sdb` the partitions are `sdb1`/`sdb2`, so
  `mkfs` and `mount` used wrong names. Now the right name is chosen once.
- **Check the removable flag (RM), not rotation (ROTA)** — the old check used
  ROTA. A USB card reader has ROTA=1 (so the real card was rejected) and an
  internal SSD has ROTA=0 (so it would pass and could be erased by mistake).
  Now it uses the real removable flag: RM=1.
- **Partition with sfdisk and size correctly** — the old code read the disk
  size from a hardcoded `/dev/mmcblk0`, and computed the end of partition 1
  with `awk "print"`, which prints big numbers in science notation
  (e.g. `6.04e+07`) that `fdisk` cannot use — so partition 2 was never made.
  Now the size comes from `blockdev --getsize64` on the chosen disk, and
  `sfdisk` creates both partitions (type 0x0c, partition 2 = 1 GiB, partition 1
  = the rest). It also unmounts before formatting and stops with a clear error
  if the two partitions do not appear.

## Notes

- The Windows script `install.ps1` was checked too. It works in a different way
  (diskpart by disk number and drive letters) and does not have these problems,
  so it is left unchanged.
- The default build options (uclibc, `WITH_PYTHON = 2`, etc.) are not changed.
  These are only fixes so the existing default build finishes.
