### PR TITLE
Fix init.sh typo that never enables RTSP/ONVIF in the config

### DIFF
--- a/SOURCE/src/sdcard/mmcblk0p2/HACK/sbin/init.sh
+++ b/SOURCE/src/sdcard/mmcblk0p2/HACK/sbin/init.sh
@@ -495,7 +495,7 @@ if [ -e $sd_lib/libavssdkbeta.so ]; then
 fi
 
 # Prepare and mount factory_cfg.ini
-if [ -e $sd_config/anyka_cgi.ini ]; then
+if [ -e $sd_config/anyka_cfg.ini ]; then
 	echo -n "Updating anyka_cfg.ini file..."
 	$sed -i -e 's/rtsp\ =\ 0/rtsp\ =\ 1/g' $sd_config/anyka_cfg.ini && \
 	$sed -i -e 's/onvif\ =\ 0/onvif\ =\ 1/g' $sd_config/anyka_cfg.ini && \


### PR DESCRIPTION
## Problem

`init.sh` has a block meant to enable RTSP and ONVIF in `anyka_cfg.ini`
(`rtsp = 1`, `onvif = 1`) and bind that config to `factory_cfg.ini`. But the
block is guarded by a filename with a typo — `anyka_cgi.ini` instead of
`anyka_cfg.ini`:

```sh
if [ -e $sd_config/anyka_cgi.ini ]; then     # "cgi" - never exists
    sed -i 's/rtsp = 0/rtsp = 1/g'  .../anyka_cfg.ini
    sed -i 's/onvif = 0/onvif = 1/g' .../anyka_cfg.ini
    mount --bind .../anyka_cfg.ini .../factory_cfg.ini
    ...
fi
```

Because `anyka_cgi.ini` never exists, the entire block is skipped, so
`anyka_cfg.ini` stays `rtsp = 0` / `onvif = 0` on every boot.

## Fix

Correct the filename to `anyka_cfg.ini` so the block runs and RTSP/ONVIF get
enabled as intended.

## How I found it

While bringing up a camera whose `anyka_ipc` has no shipped RTSP patch, I traced
why the config never had `rtsp = 1`. Fixing this typo makes the config get set
correctly (verified on the device: `rtsp = 1` / `onvif = 1` after boot).

## Note

This is a one-character fix but a behavior change for everyone: after this, all
cameras get `rtsp = 1` / `onvif = 1` written to the config on boot. That is
clearly the block's intent, but it has been dormant, so flagging it here.
