### PR TITLE
Fix DHCP race: wait for wifi association before starting udhcpc

### DIFF
--- a/SOURCE/src/sdcard/mmcblk0p2/HACK/sbin/network.sh
+++ b/SOURCE/src/sdcard/mmcblk0p2/HACK/sbin/network.sh
@@ -73,7 +73,18 @@ if [ "$wifi_config_override" = "1" ]; then
 	done
 	
 	# Setup network
-	LD_LIBRARY_PATH="/lib:/usr/lib" $wpa_supplicant -iwlan0 -D$wifi_driver -c /tmp/wpa_custom.conf > $sd_log/wpa_supplicant.log 2>&1 & $sleep 5
+	LD_LIBRARY_PATH="/lib:/usr/lib" $wpa_supplicant -iwlan0 -D$wifi_driver -c /tmp/wpa_custom.conf > $sd_log/wpa_supplicant.log 2>&1 &
+
+	# Wait for the wifi link to associate before configuring the network. A fixed
+	# sleep is not enough: the first association can time out and only succeed on a
+	# retry a few seconds later. Starting udhcpc before the link is up makes it send
+	# its discovers into a dead link and give up with no lease.
+	wpa_wait=0
+	while [ $wpa_wait -lt 30 ]; do
+		LD_LIBRARY_PATH="/lib:/usr/lib" $wpa_cli -p /var/run/wpa_supplicant -i wlan0 status 2>/dev/null | $grep "wpa_state=COMPLETED" >/dev/null 2>&1 && break
+		$sleep 1
+		wpa_wait=$((wpa_wait + 1))
+	done
 	if [ "$wifi_use_dhcp" = "1" -o "$wifi_ip_address" = "" ]; then
         network_mode="dhcp"
 		$ifconfig lo up


### PR DESCRIPTION
## Problem

`network.sh` starts `wpa_supplicant` and then waits a fixed `sleep 5` before
running `udhcpc`. But the first wifi association can time out and only succeed on
a retry a few seconds later. When that happens, `udhcpc` sends its discovers into
a link that isn't up yet and gives up — the camera never gets an IP and stays
offline.

Real log from a camera whose first association times out (before this fix):
```
wlan0: Authentication with <ap> timed out.
wlan0: CTRL-EVENT-CONNECTED ... completed      (a few seconds later)
udhcpc: broadcasting discover
udhcpc: broadcasting discover
udhcpc: broadcasting discover
udhcpc: no lease, failing
```

## Fix

Replace the fixed `sleep 5` with a wait for `wpa_state=COMPLETED` (up to 30 s),
using the same `wpa_cli status` check the script already uses further down.
`udhcpc` now starts only once the link is associated.

```sh
wpa_wait=0
while [ $wpa_wait -lt 30 ]; do
    ... $wpa_cli ... status | $grep "wpa_state=COMPLETED" >/dev/null 2>&1 && break
    $sleep 1
    wpa_wait=$((wpa_wait + 1))
done
```

## Verified on hardware

On an IPC-XC-C323 whose first association times out, DHCP previously never got a
lease. After this fix (same camera):
```
wlan0: CTRL-EVENT-CONNECTED - Connection ... completed
udhcpc: broadcasting discover
udhcpc: broadcasting select for 10.0.20.58, server 10.0.20.1
udhcpc: lease of 10.0.20.58 obtained from 10.0.20.1, lease time 21600
```
